### PR TITLE
Use colon : as the separator for key-value pairs

### DIFF
--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -136,7 +136,7 @@ module Rails
             when "{}"           then {}
             when /^['"].*['"]$/ then value[1...-1]
             when nil            then true
-            when /\A\d+\z/      then Integer(value)
+            when /^\d+$/      then Integer(value)
             else value
             end
           end

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -106,7 +106,7 @@ module Rails
 
           def parse_attr_options(options_str)
             # this allows values like for `default` that are strings with commas
-            # e.g. `text{default='hello, world!'}`
+            # e.g. `text{default:'hello, world!'}`
             provided_options = options_str.split(COMMA_NOT_CONTAINED_WITHIN_QUOTES_RE)
             provided_options.filter_map do |option|
               key, value = parse_attr_option(option)

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -26,8 +26,6 @@ module Rails
         timestamp
         token
       )
-      COLON_NOT_CONTAINED_WITHIN_BRACES_RE = /:(?![^{]*\})/
-      TYPE_WITH_OPTIONS_RE = /([^{]+)\{(.+)\}/
       COMMA_NOT_CONTAINED_WITHIN_QUOTES_RE = /,(?![^'"]*['"][^'"]*$)/
       AVAILABLE_OPTIONS = %w(
         limit

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -94,7 +94,7 @@ module Rails
             when options.blank?
               [ type, {} ]
             when %w[string text binary integer].include?(type) && options.match?(/^\d+$/)
-              [ type.to_sym, limit: options.to_i ]
+              [ type, limit: options.to_i ]
             when %w[decimal numeric].include?(type) && options.match?(/^(\d+)[,.-](\d+)$/)
               precision, scale = options.split(/[,.-]/)
               [ :decimal, precision: precision.to_i, scale: scale.to_i ]

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -184,7 +184,6 @@ module Rails
         @name           = name
         @type           = type || :string
         @has_index      = !!index_options
-        @has_uniq_index = index_options.is_a?(Hash) && index_options.key?(:unique) && index_options[:unique]
         @attr_options   = attr_options
         @index_options  = index_options || {}
       end
@@ -267,10 +266,6 @@ module Rails
         @has_index
       end
 
-      def has_uniq_index?
-        @has_uniq_index
-      end
-
       def password_digest?
         name == "password" && type == :digest
       end
@@ -300,7 +295,6 @@ module Rails
       end
 
       def inject_index_options
-        # has_uniq_index? ? ", unique: true" : ""
         (+"").tap { |s| @index_options&.each { |k, v| s << ", #{k}: #{v.inspect}" } }
       end
 

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -26,8 +26,9 @@ module Rails
         timestamp
         token
       )
+      OPTIONS_RE = /\{(.+?)\}(?![,}])/
       COMMA_NOT_CONTAINED_WITHIN_QUOTES_RE = /,(?![^'"]*['"][^'"]*$)/
-      AVAILABLE_OPTIONS = %w(
+      AVAILABLE_COLUMN_OPTIONS = %w(
         limit
         default
         null
@@ -37,6 +38,21 @@ module Rails
         polymorphic
         foreign_key
       )
+      AVAILABLE_INDEX_OPTIONS = %w(
+        unique
+        length
+        order
+        opclass
+        where
+        type
+        using
+        comment
+        algorithm
+        name
+        if_not_exists
+        internal
+        polymorphic
+      )
 
       attr_accessor :name, :type
       attr_reader   :attr_options
@@ -44,16 +60,26 @@ module Rails
 
       class << self
         def parse(column_definition)
-          optionless_column_definition = column_definition.sub(/\{(.+)\}/, "")
+          optionless_column_definition = column_definition.gsub(OPTIONS_RE, "")
           name, type, index_type = optionless_column_definition.split(":")
-          column_options = column_definition[/\{(.+)\}/, 1]
-
           # if user provided "name:index" instead of "name:string:index"
           # type should be set blank so GeneratedAttribute's constructor
           # could set it to :string
           index_type, type = type, nil if valid_index_type?(type)
 
-          type, attr_options = *parse_type_and_options(type, column_options)
+          column_options_definition = if type
+            column_definition[/#{type}\{(.+)\}(?:$|:)/, 1]
+          else
+            {}
+          end
+          index_options_definition = if index_type
+            column_definition[/#{index_type}\{(.+?)\}$/, 1] || {}
+          else
+            {}
+          end
+
+          type, attr_options = *parse_column_type_and_options(type, column_options_definition)
+          index_options = parse_index_type_and_options(index_type, index_options_definition)
           type = type.to_sym if type
 
           if type && !valid_type?(type)
@@ -64,13 +90,7 @@ module Rails
             raise Error, "Could not generate field '#{name}' with unknown index '#{index_type}'."
           end
 
-          if type && reference?(type)
-            if UNIQ_INDEX_OPTIONS.include?(index_type)
-              attr_options[:index] = { unique: true }
-            end
-          end
-
-          new(name, type, index_type, attr_options)
+          new(name, type, attr_options, index_options)
         end
 
         def valid_type?(type)
@@ -89,17 +109,42 @@ module Rails
         private
           # parse possible attribute options like :limit for string/text/binary/integer, :precision/:scale for decimals or :polymorphic for references/belongs_to
           # when declaring options curly brackets should be used
-          def parse_type_and_options(type, options)
+          def parse_column_type_and_options(type, column_options)
             case
-            when options.blank?
+            when column_options.blank?
               [ type, {} ]
-            when %w[string text binary integer].include?(type) && options.match?(/^\d+$/)
-              [ type, limit: options.to_i ]
-            when %w[decimal numeric].include?(type) && options.match?(/^(\d+)[,.-](\d+)$/)
-              precision, scale = options.split(/[,.-]/)
+            when %w[string text binary integer].include?(type) && column_options.match?(/^\d+$/)
+              [ type, limit: column_options.to_i ]
+            when %w[decimal numeric].include?(type) && column_options.match?(/^(\d+)[,.-](\d+)$/)
+              precision, scale = column_options.split(/[,.-]/)
               [ :decimal, precision: precision.to_i, scale: scale.to_i ]
             else
-              [ type, parse_attr_options(options).to_h.deep_symbolize_keys ]
+              [ type, parse_attr_options(column_options).to_h.deep_symbolize_keys ]
+            end
+          end
+
+          def parse_index_type_and_options(index_type, index_options)
+            passed_options = if index_type.nil?
+              false
+            elsif index_options.blank?
+              {}
+            elsif index_options == "{}"
+              {}
+            else
+              provided_options = index_options.split(COMMA_NOT_CONTAINED_WITHIN_QUOTES_RE)
+              provided_options.filter_map do |option|
+                key, value = parse_option(option)
+
+                next unless AVAILABLE_INDEX_OPTIONS.include?(key)
+
+                [key, value]
+              end.to_h.deep_symbolize_keys
+            end
+
+            if UNIQ_INDEX_OPTIONS.include?(index_type)
+              passed_options.merge(unique: true)
+            else
+              passed_options
             end
           end
 
@@ -108,27 +153,27 @@ module Rails
             # e.g. `text{default:'hello, world!'}`
             provided_options = options_str.split(COMMA_NOT_CONTAINED_WITHIN_QUOTES_RE)
             provided_options.filter_map do |option|
-              key, value = parse_attr_option(option)
+              key, value = parse_option(option)
 
-              next unless AVAILABLE_OPTIONS.include?(key)
+              next unless AVAILABLE_COLUMN_OPTIONS.include?(key)
 
               [key, value]
             end
           end
 
-          def parse_attr_option(option)
+          def parse_option(option)
             if option.match(/(.+):\{(.+)\}/)
               key, nested_opt = $1, $2
 
-              [key, Hash[*parse_attr_option(nested_opt)]]
+              [key, Hash[*parse_option(nested_opt)]]
             else
               key, val = option.split(":")
 
-              [key, parse_attr_value(val)]
+              [key, parse_value(val)]
             end
           end
 
-          def parse_attr_value(value)
+          def parse_value(value)
             case value
             when "true"         then true
             when "false"        then false
@@ -142,12 +187,13 @@ module Rails
           end
       end
 
-      def initialize(name, type = nil, index_type = false, attr_options = {})
+      def initialize(name, type = nil, attr_options = {}, index_options = false)
         @name           = name
         @type           = type || :string
-        @has_index      = INDEX_OPTIONS.include?(index_type)
-        @has_uniq_index = UNIQ_INDEX_OPTIONS.include?(index_type)
+        @has_index      = !!index_options
+        @has_uniq_index = index_options.is_a?(Hash) && index_options.key?(:unique) && index_options[:unique]
         @attr_options   = attr_options
+        @index_options  = index_options
       end
 
       def field_type

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -67,16 +67,8 @@ module Rails
           # could set it to :string
           index_type, type = type, nil if valid_index_type?(type)
 
-          column_options_definition = if type
-            column_definition[/#{type}\{(.+)\}(?:$|:)/, 1]
-          else
-            {}
-          end
-          index_options_definition = if index_type
-            column_definition[/#{index_type}\{(.+?)\}$/, 1] || {}
-          else
-            {}
-          end
+          column_options_definition = (column_definition[/#{type}\{(.+)\}(?:$|:)/, 1] if type) || {}
+          index_options_definition = (column_definition[/#{index_type}\{(.+?)\}$/, 1] if index_type) || {}
 
           type, attr_options = *parse_column_type_and_options(type, column_options_definition)
           index_options = parse_index_type_and_options(index_type, index_options_definition)
@@ -193,7 +185,7 @@ module Rails
         @has_index      = !!index_options
         @has_uniq_index = index_options.is_a?(Hash) && index_options.key?(:unique) && index_options[:unique]
         @attr_options   = attr_options
-        @index_options  = index_options
+        @index_options  = index_options || {}
       end
 
       def field_type
@@ -307,7 +299,8 @@ module Rails
       end
 
       def inject_index_options
-        has_uniq_index? ? ", unique: true" : ""
+        # has_uniq_index? ? ", unique: true" : ""
+        (+"").tap { |s| @index_options&.each { |k, v| s << ", #{k}: #{v.inspect}" } }
       end
 
       def options_for_migration

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -37,6 +37,7 @@ module Rails
         array
         polymorphic
         foreign_key
+        if_exists
       )
       AVAILABLE_INDEX_OPTIONS = %w(
         unique
@@ -67,7 +68,7 @@ module Rails
           # could set it to :string
           index_type, type = type, nil if valid_index_type?(type)
 
-          column_options_definition = (column_definition[/#{type}\{(.+)\}(?:$|:)/, 1] if type) || {}
+          column_options_definition = (column_definition[/#{type}\{(.+?)\}(?:$|:)/, 1] if type) || {}
           index_options_definition = (column_definition[/#{index_type}\{(.+?)\}$/, 1] if index_type) || {}
 
           type, attr_options = *parse_column_type_and_options(type, column_options_definition)

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -453,7 +453,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
 
   def test_add_migration_with_key_value_attribute_options
     migration = "add_title_and_description_to_messages"
-    run_generator [migration, "title:string{null=false}", "description:text{default='hello, world!'}"]
+    run_generator [migration, "title:string{null:false}", "description:text{default:'hello, world!'}"]
 
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |change|
@@ -465,7 +465,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
 
   def test_add_migration_ignores_unknown_key_value_attribute_options
     migration = "add_title_to_messages"
-    run_generator [migration, "title:string{null=false,foo=bar}"]
+    run_generator [migration, "title:string{null:false,foo:bar}"]
 
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |change|
@@ -478,11 +478,11 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     migration = "add_fields_to_books"
     run_generator [
       migration,
-      "title:string{limit=40,null=false,default=''}:index",
-      "content:string{limit=255,null=true}",
-      "price:decimal{precision=1,scale=2,null=false,default=0}:index",
-      "discount:decimal{precision=3,scale=4}:uniq",
-      "tags:text{array,null=false,default=[]}"
+      "title:string{limit:40,null:false,default:''}:index",
+      "content:string{limit:255,null:true}",
+      "price:decimal{precision:1,scale:2,null:false,default:0}:index",
+      "discount:decimal{precision:3,scale:4}:uniq",
+      "tags:text{array,null:false,default:[]}"
     ]
 
     assert_migration "db/migrate/#{migration}.rb" do |content|
@@ -501,7 +501,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
 
   def test_add_migration_with_nested_key_value_attribute_options
     migration = "add_title_to_messages"
-    run_generator [migration, "owner:references{foreign_key={table_name=users}}"]
+    run_generator [migration, "owner:references{foreign_key:{table_name:users}}"]
 
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |change|

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -463,6 +463,29 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_create_table_migration_with_key_value_attribute_options
+    run_generator ["create_messages", "title:string{null:false}", "description:text{default:'hello, world!'}"]
+    assert_migration "db/migrate/create_messages.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/create_table :messages/, change)
+        assert_match(/  t\.string :title, null: false/, change)
+        assert_match(/  t\.text :description, default: "hello, world!"/, change)
+      end
+    end
+  end
+
+  def test_remove_migration_with_key_value_attribute_options
+    migration = "remove_content_from_messages"
+    run_generator [migration, "title:string{null:false}", "description:text{default:'hello, world!'}"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/remove_column :messages, :title, :string, null: false/, change)
+        assert_match(/remove_column :messages, :description, :text, default: "hello, world!"/, change)
+      end
+    end
+  end
+
   def test_add_migration_ignores_unknown_key_value_attribute_options
     migration = "add_title_to_messages"
     run_generator [migration, "title:string{null:false,foo:bar}"]
@@ -470,6 +493,27 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |change|
         assert_match(/add_column :messages, :title, :string, null: false/, change)
+      end
+    end
+  end
+
+  def test_create_table_migration_ignores_unknown_key_value_attribute_options
+    run_generator ["create_messages", "title:string{null:false,foo:bar}"]
+    assert_migration "db/migrate/create_messages.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/create_table :messages/, change)
+        assert_match(/  t\.string :title, null: false/, change)
+      end
+    end
+  end
+
+  def test_remove_migration_ignores_unknown_key_value_attribute_options
+    migration = "remove_content_from_messages"
+    run_generator [migration, "title:string{null:false,foo:bar}"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/remove_column :messages, :title, :string, null: false/, change)
       end
     end
   end
@@ -499,16 +543,89 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_add_migration_with_nested_key_value_attribute_options
-    migration = "add_title_to_messages"
-    run_generator [migration, "owner:references{foreign_key:{table_name:users}}"]
+  def test_create_table_migration_with_attributes_index_declaration_and_key_value_attribute_options
+    migration = "create_messages"
+    run_generator [
+      migration,
+      "title:string{limit:40,null:false,default:''}:index",
+      "content:string{limit:255,null:true}",
+      "price:decimal{precision:1,scale:2,null:false,default:0}:index",
+      "discount:decimal{precision:3,scale:4}:uniq",
+      "tags:text{array,null:false,default:[]}"
+    ]
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/create_table :messages/, change)
+        assert_match(/  t\.string :title, limit: 40, null: false, default: ""/, change)
+        assert_match(/  t\.string :content, limit: 255, null: true/, change)
+        assert_match(/  t\.decimal :price, precision: 1, scale: 2, null: false, default: 0/, change)
+        assert_match(/  t\.decimal :discount, precision: 3, scale: 4/, change)
+        assert_match(/  t\.text :tags, array: true, null: false, default: \[\]/, change)
+      end
+      assert_match(/add_index :messages, :title/, content)
+      assert_match(/add_index :messages, :price/, content)
+      assert_match(/add_index :messages, :discount, unique: true/, content)
+    end
+  end
+
+  def test_remove_migration_with_attributes_index_declaration_and_key_value_attribute_options
+    migration = "remove_content_from_messages"
+    run_generator [
+      migration,
+      "title:string{limit:40,null:false,default:''}:index",
+      "content:string{limit:255,null:true}",
+      "price:decimal{precision:1,scale:2,null:false,default:0}:index",
+      "discount:decimal{precision:3,scale:4}:uniq",
+      "tags:text{array,null:false,default:[]}"
+    ]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/remove_column :messages, :title, :string, limit: 40, null: false, default: ""/, change)
+        assert_match(/remove_column :messages, :content, :string, limit: 255, null: true/, change)
+        assert_match(/remove_column :messages, :price, :decimal, precision: 1, scale: 2, null: false, default: 0/, change)
+        assert_match(/remove_column :messages, :discount, :decimal, precision: 3, scale: 4/, change)
+        assert_match(/remove_column :messages, :tags, :text, array: true, null: false, default: \[\]/, change)
+
+        assert_match(/remove_index :messages, :title/, change)
+        assert_match(/remove_index :messages, :price/, change)
+        assert_match(/remove_index :messages, :discount, unique: true/, change)
+      end
+    end
+  end
+
+  def test_add_migration_with_nested_key_value_attribute_options_and_index_options_ignores_index_options
+    migration = "add_owner_to_messages"
+    run_generator [migration, "owner:references{foreign_key:{table_name:users}}:uniq{length:{name:10,surname:15}}"]
 
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |change|
         assert_match(/add_reference :messages, :owner, foreign_key: {:table_name=>"users"}, null: false/, change)
       end
+      assert_no_match(/add_index :messages, :owner, unique: true, length: {name: 10, surname:15}/, content)
     end
   end
+
+  # def test_create_table_migration_ignores_unknown_key_value_attribute_options
+  #   run_generator ["create_messages", "title:string{null:false,foo:bar}"]
+  #   assert_migration "db/migrate/create_messages.rb" do |content|
+  #     assert_method :change, content do |change|
+  #       assert_match(/create_table :messages/, change)
+  #       assert_match(/  t\.string :title, null: false/, change)
+  #     end
+  #   end
+  # end
+  #
+  # def test_remove_migration_ignores_unknown_key_value_attribute_options
+  #   migration = "remove_content_from_messages"
+  #   run_generator [migration, "title:string{null:false,foo:bar}"]
+  #
+  #   assert_migration "db/migrate/#{migration}.rb" do |content|
+  #     assert_method :change, content do |change|
+  #       assert_match(/remove_column :messages, :title, :string, null: false/, change)
+  #     end
+  #   end
+  # end
 
   def test_add_migration_with_key_value_index_options
     migration = "add_title_to_messages"

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -510,7 +510,37 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  ""
+  def test_add_migration_with_key_value_index_options
+    migration = "add_title_to_messages"
+    run_generator [migration, "title:string:uniq{name:by_title}"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/add_column :messages, :title, :string/, change)
+      end
+      assert_match(/add_index :messages, :title, name: "by_title", unique: true/, content)
+    end
+  end
+
+  # "owner:references{foreign_key:{table_name:users},null:false}:uniq{using:btree}"
+  # "owner:references{foreign_key:{table_name:users},null:false}:uniq"
+  # name:string, name:string:uniq, name:uniq, name:string{null:false}:uniq, and name:string{null:false}
+  # unique: true
+  # unique: true, name: 'by_branch_party'
+  # name: 'by_name', length: 10
+  # name: 'by_name_surname', length: {name: 10, surname: 15}
+  # order: {branch_id: :desc, party_id: :asc}
+  # unique: true, where: "active"
+  # using: 'btree'
+  # using: 'gist', opclass: :gist_trgm_ops
+  # using: 'gist', opclass: { city: :gist_trgm_ops }
+  # type: :fulltext
+  # algorithm: :concurrently
+  # "owner:references:index"
+  # "owner:references:uniq"
+  # "owner:references:uniq{name:by_branch_party}"
+  # "owner:references{foreign_key:{table_name:users},null:false}:index"
+  # "owner:references{foreign_key:{table_name:users},null:false}:uniq{name:by_name_surname,length:{name:10,surname:15},order:{name:desc,surname:asc}}"
 
   private
     def with_singular_table_name


### PR DESCRIPTION
Building on top of the refactoring for nested key-value pairs, this shows how to enable `:` as the separator for key-value pairs, while still retaining it as the outer separator for name, type, and index_type.

cc: @kaspth